### PR TITLE
Only require guzzle at >=3.8,<4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "~3.8.0"
+        "guzzle/guzzle": "~3.8"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
There isn't much reason to not allow newer guzzle 3 and limiting to 3.8.x conflicts with libs that expect 3.9+.

https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator-
